### PR TITLE
fix: semgrep finding for useless-assignment-keyed

### DIFF
--- a/target-templates-update/target-templates-update.py
+++ b/target-templates-update/target-templates-update.py
@@ -824,9 +824,10 @@ def update_template_ids(
                     LOGGER.debug(
                         template_data["LaunchTemplateData"].get("IamInstanceProfile")
                     )
-                    launch_template_data_parameter["IamInstanceProfile"] = {}
                     launch_template_data_parameter["IamInstanceProfile"] = (
-                        template_data["LaunchTemplateData"].get("IamInstanceProfile")
+                        template_data["LaunchTemplateData"].get(
+                            "IamInstanceProfile", {}
+                        )
                     )
                     LOGGER.debug(launch_template_data_parameter["IamInstanceProfile"])
                 else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

semgrep is reporting that:

> Rule ID: useless-assignment-keyed Message: key `"IamInstanceProfile"` in `launch_template_data_parameter` is assigned twice; the first assignment is useless

This removes the first assignment of the key, resolving the finding.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
