### PR TITLE
chore: set permissions to read-all for github workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

checkov is reporting:
> CKV2_GHA_1: Ensure top-level permissions are not set to write-all

This change sets the permissions to read-all in order to resolve the finding.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
