### PR TITLE
fix: refactor except pass to get then check none

### DIFF
--- a/target-templates-update/target-templates-update.py
+++ b/target-templates-update/target-templates-update.py
@@ -919,15 +919,13 @@ def get_network_interfaces_info(network_interfaces):
             except:
                 return_network_interface["DeleteOnTermination"] = True
 
-            try:
-                return_network_interface["Groups"] = network_interface["Groups"]
-            except:
-                pass
+            groups = network_interface.get("Groups")
+            if groups is not None:
+                return_network_interface["Groups"] = groups
 
-            try:
-                return_network_interface["SubnetId"] = network_interface["SubnetId"]
-            except:
-                pass
+            subnet_id = network_interface.get("SubnetId")
+            if subnet_id is not None:
+                return_network_interface["SubnetId"] = subnet_id
 
     return return_network_interface
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

bandit is reporting that:

> B110: Try, Except, Pass detected.

This change refactors the code so that it doesn't use a try except pass. Instead it tries to retrieve the value from the dictionary using the get method. If the key does not exist, then None will be returned. We then check if the returned value is None and proceed accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
