### PR TITLE
fix: Reset AssociatePublicIpAddress and DeleteOnTermination for provided ENI

### DIFF
--- a/target-templates-import/target_templates_import.py
+++ b/target-templates-import/target_templates_import.py
@@ -474,6 +474,8 @@ def update_launch_config(
                     network_interface.pop("SubnetId", None)
                     network_interface.pop("Groups", None)
                     network_interface.pop("PrivateIpAddresses", None)
+                    network_interface.pop("AssociatePublicIpAddress", None)
+                    network_interface.pop("DeleteOnTermination", None)
 
     blk_device_mappings = new_ec2_launch_template["LaunchTemplateData"][
         "BlockDeviceMappings"


### PR DESCRIPTION
*Issue #, if available:*

Closes #38 

*Description of changes:*

This PR fixes the issue where the "auto-assign public IP" and "delete on termination" settings are specified for a provided ENI instead of inheriting from the existing ENI, thus causing validation errors in the launch template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
